### PR TITLE
replaced deprecated pandas lineterminator arg

### DIFF
--- a/pandas_plink/_write.py
+++ b/pandas_plink/_write.py
@@ -264,7 +264,7 @@ def _write_fam(filepath: Path, G: DataArray):
         sep="\t",
         header=False,
         encoding="ascii",
-        line_terminator="\n",
+        lineterminator="\n",
     )
 
 
@@ -291,5 +291,5 @@ def _write_bim(filepath: Path, G: DataArray):
         sep="\t",
         header=False,
         encoding="ascii",
-        line_terminator="\n",
+        lineterminator="\n",
     )


### PR DESCRIPTION
Newer versions of pandas (2+) cause _write_bim and _write_fam to fail. This change ('line_terminator' -> 'lineterminator' in calls to pandas.DataFrame.to_csv) works for both new and old pandas versions.